### PR TITLE
Add Lorentzian separation calculation

### DIFF
--- a/MoonAngleCondition/MoonAngleCondition.cs
+++ b/MoonAngleCondition/MoonAngleCondition.cs
@@ -42,6 +42,7 @@ namespace DaleGhent.NINA.MoonAngle.MoonAngleCondition {
         private int width = 14;
         private double currentSeparation = 0;
         private double separationLimit = 20;
+        private double lseparation = 20;
         private ComparisonOperatorEnum comparisonOperator = ComparisonOperatorEnum.LESS_THAN_OR_EQUAL;
 
         private readonly IProfileService profileService;
@@ -77,9 +78,19 @@ namespace DaleGhent.NINA.MoonAngle.MoonAngleCondition {
             get => separationLimit;
             set {
                 if (lorentzian) {
+                    Lseparation = value;
                     value = LorentzianSeparation(value, width);
                 }
                 separationLimit = value < 0d ? 0 : value > 180d ? 180 : Math.Round(value, 2);
+                RaisePropertyChanged();
+            }
+        }
+
+        [JsonProperty]
+        public double Lseparation {
+            get => lseparation;
+            set {
+                lseparation = value;
                 RaisePropertyChanged();
             }
         }

--- a/MoonAngleCondition/MoonAngleConditionTemplate.xaml
+++ b/MoonAngleCondition/MoonAngleConditionTemplate.xaml
@@ -66,6 +66,34 @@
                     <TextBlock
                         Margin="5,0,0,0"
                         VerticalAlignment="Center"
+                        Text="Distance: ">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Lorentzian}" Value="False">
+                                        <Setter Property="Visibility" Value="Hidden" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <TextBlock
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="{Binding Lseparation}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Lorentzian}" Value="False">
+                                        <Setter Property="Visibility" Value="Hidden" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <TextBlock
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
                         Text="Width: ">
                         <TextBlock.Style>
                             <Style TargetType="TextBlock">

--- a/MoonAngleCondition/MoonAngleConditionTemplate.xaml
+++ b/MoonAngleCondition/MoonAngleConditionTemplate.xaml
@@ -3,18 +3,17 @@
 
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
-    file, You can obtain one at http://mozilla.org/MPL/2.0/
--->
+    file, You can obtain one at http://mozilla.org/MPL/2.0/-->
 <ResourceDictionary
     x:Class="DaleGhent.NINA.MoonAngle.MoonAngleCondition.MoonAngleConditionTemplate"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:ns="clr-namespace:NINA.Core.Locale;assembly=NINA.Core"
-    xmlns:ninactrl="clr-namespace:NINACustomControlLibrary;assembly=NINACustomControlLibrary"
-    xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
     xmlns:local="clr-namespace:DaleGhent.NINA.MoonAngle.MoonAngleCondition"
     xmlns:mini="clr-namespace:NINA.View.Sequencer.MiniSequencer;assembly=NINA.Sequencer"
-    xmlns:nina="clr-namespace:NINA.View.Sequencer;assembly=NINA.Sequencer">
+    xmlns:nina="clr-namespace:NINA.View.Sequencer;assembly=NINA.Sequencer"
+    xmlns:ninactrl="clr-namespace:NINACustomControlLibrary;assembly=NINACustomControlLibrary"
+    xmlns:ns="clr-namespace:NINA.Core.Locale;assembly=NINA.Core"
+    xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core">
 
     <GeometryGroup x:Key="MoonAngle_SVG">
         <PathGeometry Figures="M 208.652,27.0106C 95.2201,53.6359 15.0267,154.812 15.0001,271.323C 15.0001,337.896 41.4481,401.74 88.5214,448.812C 135.595,495.885 199.439,522.333 266.011,522.333C 323.177,522.317 378.631,502.792 423.193,466.984C 400.835,473.109 377.729,476.084 354.553,475.828C 217.308,474.031 107.333,361.631 108.532,224.38C 109.272,146.573 146.303,73.5679 208.652,27.0106 Z " />
@@ -46,13 +45,24 @@
                         TextAlignment="Right"
                         Unit="°">
                         <ninactrl:UnitTextBox.Text>
-                            <Binding Path="SeparationLimit" StringFormat="0.00" UpdateSourceTrigger="LostFocus" />
+                            <Binding
+                                Path="SeparationLimit"
+                                StringFormat="0.00"
+                                UpdateSourceTrigger="LostFocus" />
                         </ninactrl:UnitTextBox.Text>
                     </ninactrl:UnitTextBox>
                     <TextBlock
                         Margin="5,0,0,0"
                         VerticalAlignment="Center"
                         Text="from the moon" />
+                    <TextBlock
+                        Margin="30,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="Lorentzian" />
+                    <CheckBox
+                        Height="20"
+                        Margin="5,0,0,0"
+                        IsChecked="{Binding Lorentzian, Mode=TwoWay}" />
                 </StackPanel>
             </nina:SequenceBlockView.SequenceItemContent>
 

--- a/MoonAngleCondition/MoonAngleConditionTemplate.xaml
+++ b/MoonAngleCondition/MoonAngleConditionTemplate.xaml
@@ -63,6 +63,35 @@
                         Height="20"
                         Margin="5,0,0,0"
                         IsChecked="{Binding Lorentzian, Mode=TwoWay}" />
+                    <TextBlock
+                        Margin="5,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="Width: ">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Lorentzian}" Value="False">
+                                        <Setter Property="Visibility" Value="Hidden" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    <TextBox
+                        MinWidth="40"
+                        Margin="5,0,0,0"
+                        Text="{Binding Width}"
+                        TextAlignment="Right">
+                        <TextBox.Style>
+                            <Style TargetType="TextBox">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Lorentzian}" Value="False">
+                                        <Setter Property="Visibility" Value="Hidden" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBox.Style>
+                    </TextBox>
                 </StackPanel>
             </nina:SequenceBlockView.SequenceItemContent>
 

--- a/MoonAngleCondition/MoonAngleConditionTemplate.xaml
+++ b/MoonAngleCondition/MoonAngleConditionTemplate.xaml
@@ -13,7 +13,8 @@
     xmlns:nina="clr-namespace:NINA.View.Sequencer;assembly=NINA.Sequencer"
     xmlns:ninactrl="clr-namespace:NINACustomControlLibrary;assembly=NINACustomControlLibrary"
     xmlns:ns="clr-namespace:NINA.Core.Locale;assembly=NINA.Core"
-    xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core">
+    xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
+    xmlns:util="clr-namespace:NINA.Core.Utility;assembly=NINA.Core">
 
     <GeometryGroup x:Key="MoonAngle_SVG">
         <PathGeometry Figures="M 208.652,27.0106C 95.2201,53.6359 15.0267,154.812 15.0001,271.323C 15.0001,337.896 41.4481,401.74 88.5214,448.812C 135.595,495.885 199.439,522.333 266.011,522.333C 323.177,522.317 378.631,502.792 423.193,466.984C 400.835,473.109 377.729,476.084 354.553,475.828C 217.308,474.031 107.333,361.631 108.532,224.38C 109.272,146.573 146.303,73.5679 208.652,27.0106 Z " />
@@ -55,85 +56,97 @@
                         Margin="5,0,0,0"
                         VerticalAlignment="Center"
                         Text="from the moon" />
+
                     <TextBlock
-                        Margin="30,0,0,0"
+                        Margin="10,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="|" />
+
+                    <TextBlock
+                        Margin="10,0,0,0"
                         VerticalAlignment="Center"
                         Text="Lorentzian" />
                     <CheckBox
-                        Height="20"
                         Margin="5,0,0,0"
                         IsChecked="{Binding Lorentzian, Mode=TwoWay}" />
-                    <TextBlock
+
+                    <StackPanel
                         Margin="5,0,0,0"
-                        VerticalAlignment="Center"
-                        Text="Distance: ">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
+                        Orientation="Horizontal"
+                        VerticalAlignment="Center">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding Lorentzian}" Value="False">
                                         <Setter Property="Visibility" Value="Hidden" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
-                    <TextBlock
-                        Margin="5,0,0,0"
-                        VerticalAlignment="Center"
-                        Text="{Binding Lseparation}">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Lorentzian}" Value="False">
-                                        <Setter Property="Visibility" Value="Hidden" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
-                    <TextBlock
-                        Margin="5,0,0,0"
-                        VerticalAlignment="Center"
-                        Text="Width: ">
-                        <TextBlock.Style>
-                            <Style TargetType="TextBlock">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Lorentzian}" Value="False">
-                                        <Setter Property="Visibility" Value="Hidden" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
-                    <TextBox
-                        MinWidth="40"
-                        Margin="5,0,0,0"
-                        Text="{Binding Width}"
-                        TextAlignment="Right">
-                        <TextBox.Style>
-                            <Style TargetType="TextBox">
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding Lorentzian}" Value="False">
-                                        <Setter Property="Visibility" Value="Hidden" />
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </TextBox.Style>
-                    </TextBox>
+                        </StackPanel.Style>
+
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="Width: " />
+
+                        <ninactrl:UnitTextBox
+                            MinWidth="40"
+                            Margin="5,0,0,0"
+                            Unit="days"
+                            TextAlignment="Right">
+                            <Binding Path="LorentzianWidth" UpdateSourceTrigger="LostFocus">
+                                <Binding.ValidationRules>
+                                    <rules:IntRangeRule>
+                                        <rules:IntRangeRule.ValidRange>
+                                            <rules:IntRangeChecker Maximum="15" Minimum="0" />
+                                        </rules:IntRangeRule.ValidRange>
+                                    </rules:IntRangeRule>
+                                </Binding.ValidationRules>
+                            </Binding>
+                            <ninactrl:UnitTextBox.ToolTip>
+                                <TextBlock
+                                    TextAlignment="Justify"
+                                    Text="The number of days prior to or after a full moon where the separation distance will be half of the specified target-moon separation distance." />
+                            </ninactrl:UnitTextBox.ToolTip>
+                        </ninactrl:UnitTextBox>
+                    </StackPanel>
                 </StackPanel>
             </nina:SequenceBlockView.SequenceItemContent>
 
             <nina:SequenceBlockView.SequenceItemProgressContent>
-                <StackPanel Orientation="Horizontal">
-                    <TextBlock
-                        Margin="5,0,0,0"
-                        VerticalAlignment="Center"
-                        Text="Current target-moon separation:" />
-                    <TextBlock
-                        Margin="5,0,0,0"
-                        VerticalAlignment="Center"
-                        Text="{Binding CurrentSeparation, StringFormat={}{0:0.00}}" />
-                    <TextBlock VerticalAlignment="Center" Text="° " />
+                <StackPanel Orientation="Vertical">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="Current target-moon separation:" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="{Binding ActualSeparation, StringFormat={}{0:0.00}}" />
+                        <TextBlock VerticalAlignment="Center" Text="° " />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Lorentzian}" Value="False">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>
+
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="Lorentizan-modified limit:" />
+                        <TextBlock
+                            Margin="5,0,0,0"
+                            VerticalAlignment="Center"
+                            Text="{Binding LorentzianSeparationLimit, StringFormat={}{0:0.00}}" />
+                        <TextBlock VerticalAlignment="Center" Text="° " />
+                    </StackPanel>
                 </StackPanel>
             </nina:SequenceBlockView.SequenceItemProgressContent>
         </nina:SequenceBlockView>
@@ -163,7 +176,7 @@
                     <TextBlock
                         Margin="5,0,0,0"
                         VerticalAlignment="Center"
-                        Text="{Binding CurrentSeparation, StringFormat={}{0:0.00}}" />
+                        Text="{Binding ActualSeparation, StringFormat={}{0:0.00}}" />
                     <TextBlock VerticalAlignment="Center" Text="°" />
                     <TextBlock
                         Margin="0,0,0,0"

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -54,6 +54,11 @@ using System.Runtime.InteropServices;
 
 This loop condition appears under the **Loop Condition** category of instructions.
 
+The switch labelled **Lorentzian** enables modification of the submitted angle based on the Lorentzian Moon Avoidance algorithm forumlated by the Berkely Automated Imaging Telescope team.
+When enabled, N.I.N.A. will assume that the desired angular distance is that required under a full moon; it will calculate the current position in the lunar cycle and reduce the angle
+such that at **width** days before (or after) the full moon the angular distance will be halved.  The default width of 14 is a reasonable starting point.
+The calculation uses the formula provided at http://bobdenny.com/ar/RefDocs/HelpFiles/ACPScheduler81Help/Constraints.htm with thanks.
+
 # Getting help #
 
 Help for this plugin may be found in the **#plugin-discussions** channel on the NINA project [Discord chat server](https://discord.gg/nighttime-imaging) or by filing an issue report at this plugin's [Github repository](https://github.com/daleghent/nina-moon-angle/issues).")]
@@ -67,4 +72,4 @@ Help for this plugin may be found in the **#plugin-discussions** channel on the 
 // [Unused]
 [assembly: AssemblyTrademark("")]
 // [Unused]
-[assembly: AssemblyCulture("")] 
+[assembly: AssemblyCulture("")]

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -54,10 +54,14 @@ using System.Runtime.InteropServices;
 
 This loop condition appears under the **Loop Condition** category of instructions.
 
-The switch labelled **Lorentzian** enables modification of the submitted angle based on the Lorentzian Moon Avoidance algorithm forumlated by the Berkely Automated Imaging Telescope team.
-When enabled, N.I.N.A. will assume that the desired angular distance is that required under a full moon; it will calculate the current position in the lunar cycle and reduce the angle
-such that at **width** days before (or after) the full moon the angular distance will be halved.  The default width of 14 is a reasonable starting point.
-The calculation uses the formula provided at http://bobdenny.com/ar/RefDocs/HelpFiles/ACPScheduler81Help/Constraints.htm with thanks.
+# Lorentzian Moon Avoidance #
+
+The **Lorentzian** option modifies the calculated target-moon separation angle based on the Lorentzian Moon Avoidance (LMA) algorithm, forumlated by the [Berkely Automated Imaging Telescope](https://w.astro.berkeley.edu/bait/) team.
+When enabled, N.I.N.A. will assume that the specified separation distance assumes a full moon at its most luminous phase. The LMA algorithm will use _current_ phase of the lunar cycle to reduce the specified separaration angle.
+The result is that the condition will allow imaging to take place closer to the moon the less full, and thus less bright, it is.
+
+The separation is reduced such that by **width** days before (or after) the full moon the specified separation distance will be halved. The default width of 14 days is a reasonable starting point.
+The calculation uses [the LMA formula](http://bobdenny.com/ar/RefDocs/HelpFiles/ACPScheduler81Help/Constraints.htm) provided, with thanks, by Bob Denny of [DC3 Dreams](http://dc3.com/).
 
 # Getting help #
 
@@ -72,4 +76,4 @@ Help for this plugin may be found in the **#plugin-discussions** channel on the 
 // [Unused]
 [assembly: AssemblyTrademark("")]
 // [Unused]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyCulture("")] 


### PR DESCRIPTION
Add automatic calculation of Lorentzian moon avoidance.  This will automatically change the specified separation distance based on the current phase of the moon, e.g. if you are OK to image at 120 degrees from the moon on a full moon, then on day 5 of the lunar cycle you can happily image 80 degrees away.  This chart shows how the maths works out:

<img width="501" alt="image" src="https://user-images.githubusercontent.com/22751629/158001533-c7786554-a54c-4673-9966-25f03ca869b1.png">

Should probably add the width parameter too, currently hard coded to 14 but width changes the curve -- here's 120 degrees at widths of 7, 10 and 14 days:

<img width="501" alt="image" src="https://user-images.githubusercontent.com/22751629/158001582-99798153-2414-4b74-8507-dcc3a378aa53.png">

Formula is taken from ACP, as described in http://bobdenny.com/ar/RefDocs/HelpFiles/ACPScheduler81Help/Constraints.htm  but the maths originally came from UCB.